### PR TITLE
Método .getBytes na GraalVM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
     "func-call-spacing": ["error", "never"],
     "generator-star-spacing": ["error", { "before": true, "after": true }],
     "handle-callback-err": ["error", "^(err|error)$"],
-    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "indent": ["error", 4, { "SwitchCase": 2 }],
     "key-spacing": ["error", { "beforeColon": false, "afterColon": true }],
     "keyword-spacing": ["error", { "before": true, "after": true }],
     "new-cap": ["error", { "newIsCap": true, "capIsNew": false }],

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JWT 0.0.7
+# JWT 0.1.4
 
 JWT é um *bitcode* de serialização/deserialização de JSON Web Token para [ThrustJS](https://github.com/thrustjs/thrust)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JWT
+# JWT 0.0.7
 
 JWT é um *bitcode* de serialização/deserialização de JSON Web Token para [ThrustJS](https://github.com/thrustjs/thrust)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-JWT
-===============
+# JWT
 
 JWT é um *bitcode* de serialização/deserialização de JSON Web Token para [ThrustJS](https://github.com/thrustjs/thrust)
 
-# Instalação
+## Instalação
 
 Posicionado em um app [ThrustJS](https://github.com/thrustjs/thrust), no seu terminal:
 
-```bash
-thrust install jwt
+```sh
+tpm install ozaijr/jwt
 ```
 
 ## Tutorial
@@ -46,6 +45,7 @@ deserialize(serializedJwt, encrypted)
 ```
 
 ## Parâmetros de configuração
+
 As propriedades abaixo devem ser configuradas no arquivo *config.json* (distribuído juntamente com o ThrustJS):
 
 ``` javascript

--- a/index.js
+++ b/index.js
@@ -18,79 +18,89 @@ var AlgorithmConstraints = Java.type('org.jose4j.jwa.AlgorithmConstraints')
 var ConstraintType = Java.type('org.jose4j.jwa.AlgorithmConstraints.ConstraintType')
 
 var jwt = {
-  /**
-   * Função que gera um **jwt** a partir de um *payload*.
-   * @param {Object} payload - propriedades que serão inseridas no payload do jwt.
-   * @param {Boolean} encrypt - indica se o token deve ou não ser criptografado. Por padrão não é criptografado.
-   * @return {String} retorna o jwt.
-   */
-  serialize: function (payload, encrypt) {
-    return encrypt ? serializeEncryptedToken(payload) : serializeToken(payload)
-  },
-  /**
-   * Função que extrai o *payload* de um **jwt** serializado.
-   * @param {String} serializedJwt - jwt em formato string (*serializado*).
-   * @param {Boolean} encrypt - indica se o token a ser lido está criptografado.
-   * @return {String} retorna o payload serializado (JSON).
-   */
-  deserialize: function (serializedJwt, encrypted) {
-    return encrypted ? deserializeEncryptedToken(serializedJwt) : deserializeToken(serializedJwt)
-  }
+    /**
+    * Função que gera um **jwt** a partir de um *payload*.
+    * @param {Object} payload - propriedades que serão inseridas no payload do jwt.
+    * @param {Boolean} encrypt - indica se o token deve ou não ser criptografado. Por padrão não é criptografado.
+    * @return {String} retorna o jwt.
+    */
+    serialize: function (payload, encrypt) {
+        return encrypt ? serializeEncryptedToken(payload) : serializeToken(payload)
+    },
+    /**
+    * Função que extrai o *payload* de um **jwt** serializado.
+    * @param {String} serializedJwt - jwt em formato string (*serializado*).
+    * @param {Boolean} encrypt - indica se o token a ser lido está criptografado.
+    * @return {String} retorna o payload serializado (JSON).
+    */
+    deserialize: function (serializedJwt, encrypted) {
+        return encrypted ? deserializeEncryptedToken(serializedJwt) : deserializeToken(serializedJwt)
+    }
+}
+
+function getBytes (str, charset) {
+    str = str || ''
+    charset = charset || 'utf-8'
+    if (!str.getBytes) {
+        let StringHelper = Java.type('br.com.softbox.thrust.api.ThrustStringHelper')
+        return StringHelper.getBytes(str, charset)
+    }
+    return str.getBytes(charset)
 }
 
 function serializeToken (payload) {
-  var jws = new JsonWebSignature()
-  jws.setPayload(JSON.stringify(payload))
-  jws.setKey(getKey())
-  jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256)
-  jws.setHeader("typ", "JWT")
-  jws.setDoKeyValidation(false)
-  return jws.getCompactSerialization()
+    var jws = new JsonWebSignature()
+    jws.setPayload(JSON.stringify(payload))
+    jws.setKey(getKey())
+    jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.HMAC_SHA256)
+    jws.setHeader('typ', 'JWT')
+    jws.setDoKeyValidation(false)
+    return jws.getCompactSerialization()
 }
 
 function deserializeToken (token) {
-  var jws = new JsonWebSignature()
-  jws.setCompactSerialization(token)
-  jws.setKey(getKey())
-  jws.setDoKeyValidation(false)
-  return jws.getPayload()
+    var jws = new JsonWebSignature()
+    jws.setCompactSerialization(token)
+    jws.setKey(getKey())
+    jws.setDoKeyValidation(false)
+    return jws.getPayload()
 }
 
 function serializeEncryptedToken (payload) {
-  var jwe = new JsonWebEncryption()
-  var key = getEncryptionKey()
-  jwe.setAlgorithmHeaderValue(KeyManagementAlgorithmIdentifiers.A128KW)
-  jwe.setEncryptionMethodHeaderParameter(ContentEncryptionAlgorithmIdentifiers.AES_128_CBC_HMAC_SHA_256)
-  jwe.setPayload(JSON.stringify(payload))
-  jwe.setKey(key)
-  return jwe.getCompactSerialization()
+    var jwe = new JsonWebEncryption()
+    var key = getEncryptionKey()
+    jwe.setAlgorithmHeaderValue(KeyManagementAlgorithmIdentifiers.A128KW)
+    jwe.setEncryptionMethodHeaderParameter(ContentEncryptionAlgorithmIdentifiers.AES_128_CBC_HMAC_SHA_256)
+    jwe.setPayload(JSON.stringify(payload))
+    jwe.setKey(key)
+    return jwe.getCompactSerialization()
 }
 
 function deserializeEncryptedToken (encryptJWT) {
-  var jwe = new JsonWebEncryption()
-  var key = getEncryptionKey()
-  jwe.setAlgorithmConstraints(new AlgorithmConstraints(ConstraintType.WHITELIST, KeyManagementAlgorithmIdentifiers.A128KW))
-  jwe.setContentEncryptionAlgorithmConstraints(new AlgorithmConstraints(ConstraintType.WHITELIST, ContentEncryptionAlgorithmIdentifiers.AES_128_CBC_HMAC_SHA_256))
-  jwe.setKey(key)
-  jwe.setCompactSerialization(encryptJWT)
-  return jwe.getPayload()
+    var jwe = new JsonWebEncryption()
+    var key = getEncryptionKey()
+    jwe.setAlgorithmConstraints(new AlgorithmConstraints(ConstraintType.WHITELIST, KeyManagementAlgorithmIdentifiers.A128KW))
+    jwe.setContentEncryptionAlgorithmConstraints(new AlgorithmConstraints(ConstraintType.WHITELIST, ContentEncryptionAlgorithmIdentifiers.AES_128_CBC_HMAC_SHA_256))
+    jwe.setKey(key)
+    jwe.setCompactSerialization(encryptJWT)
+    return jwe.getPayload()
 }
 
-function jwtConfig(name) {
-  try {
-    return env('jwt.' + name)
-  } catch(e) {
-    return getBitcodeConfig('jwt')(name);
-  }
+function jwtConfig (name) {
+    try {
+        return env('jwt.' + name)
+    } catch (e) {
+        return getBitcodeConfig('jwt')(name)
+    }
 }
 
-function getKey() {
-  var key = new java.lang.String(jwtConfig('jwtKey'))
-  return new HmacKey(key.getBytes("UTF-8"))
+function getKey () {
+    var key = jwtConfig('jwtKey')
+    return new HmacKey(getBytes(key))
 }
 
-function getEncryptionKey() {
-  return new AesKey(new java.lang.String(jwtConfig('jwsKey')).getBytes())
+function getEncryptionKey () {
+    return new AesKey(getBytes(jwtConfig('jwsKey')))
 }
 
 exports = jwt

--- a/index.js
+++ b/index.js
@@ -122,6 +122,10 @@ function getKey () {
 }
 
 function getEncryptionKey () {
+    var key  = jwtConfig('jwsKey')
+    if (!key) {
+        throw new Error('No jwsKey from config for JWT')
+    }
     return new AesKey(getBytes(jwtConfig('jwsKey')))
 }
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,28 @@ var AlgorithmConstraints = Java.type('org.jose4j.jwa.AlgorithmConstraints')
 /** @ignore */
 var ConstraintType = Java.type('org.jose4j.jwa.AlgorithmConstraints.ConstraintType')
 
+function getBitcodeConfig(bitcode) {
+    const config = getConfig()
+
+    return (property, appId) => {
+        const propertyPath = property ? property.split('.') : []
+
+        let result = propertyPath.reduce((map, currProp) => {
+            if (map && map[currProp]) {
+                return map[currProp]
+            } else {
+                return undefined
+            }
+        }, config)
+
+        if (appId && typeof result === 'object' && result[appId]) {
+            result = result[appId]
+        }
+
+        return result
+    }
+}
+
 var jwt = {
     /**
     * Função que gera um **jwt** a partir de um *payload*.

--- a/index.js
+++ b/index.js
@@ -17,28 +17,6 @@ var AlgorithmConstraints = Java.type('org.jose4j.jwa.AlgorithmConstraints')
 /** @ignore */
 var ConstraintType = Java.type('org.jose4j.jwa.AlgorithmConstraints.ConstraintType')
 
-function getBitcodeConfig(bitcode) {
-    const config = getConfig()
-
-    return (property, appId) => {
-        const propertyPath = property ? property.split('.') : []
-
-        let result = propertyPath.reduce((map, currProp) => {
-            if (map && map[currProp]) {
-                return map[currProp]
-            } else {
-                return undefined
-            }
-        }, config)
-
-        if (appId && typeof result === 'object' && result[appId]) {
-            result = result[appId]
-        }
-
-        return result
-    }
-}
-
 var jwt = {
     /**
     * Função que gera um **jwt** a partir de um *payload*.
@@ -112,7 +90,8 @@ function jwtConfig (name) {
     try {
         return env('jwt.' + name)
     } catch (e) {
-        return getBitcodeConfig('jwt')(name)
+        var cfg = getConfig()
+        return cfg && cfg.jwt && cfg.jwt[name]
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var ByteArrayOutputStream = Java.type('java.io.ByteArrayOutputStream')
 var OutputStreamWriter = Java.type('java.io.OutputStreamWriter')
 
 var jwt = {
-    version: '0.0.7',
+    version: '0.1.4',
     /**
     * Função que gera um **jwt** a partir de um *payload*.
     * @param {Object} payload - propriedades que serão inseridas no payload do jwt.

--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ var AlgorithmConstraints = Java.type('org.jose4j.jwa.AlgorithmConstraints')
 /** @ignore */
 var ConstraintType = Java.type('org.jose4j.jwa.AlgorithmConstraints.ConstraintType')
 
+var BufferedWriter = Java.type('java.io.BufferedWriter')
+var ByteArrayOutputStream = Java.type('java.io.ByteArrayOutputStream')
+var OutputStreamWriter = Java.type('java.io.OutputStreamWriter')
+
 var jwt = {
     /**
     * Função que gera um **jwt** a partir de um *payload*.
@@ -42,8 +46,14 @@ function getBytes (str, charset) {
     str = str || ''
     charset = charset || 'utf-8'
     if (!str.getBytes) {
-        let StringHelper = Java.type('br.com.softbox.thrust.api.ThrustStringHelper')
-        return StringHelper.getBytes(str, charset)
+        var bos = new ByteArrayOutputStream()
+        var out = new BufferedWriter(new OutputStreamWriter(bos, charset))
+        out.append(str)
+        out.flush()
+        var strBytes = bos.toByteArray()
+        out.close()
+
+        return strBytes
     }
     return str.getBytes(charset)
 }
@@ -101,7 +111,7 @@ function getKey () {
 }
 
 function getEncryptionKey () {
-    var key  = jwtConfig('jwsKey')
+    var key = jwtConfig('jwsKey')
     if (!key) {
         throw new Error('No jwsKey from config for JWT')
     }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var ByteArrayOutputStream = Java.type('java.io.ByteArrayOutputStream')
 var OutputStreamWriter = Java.type('java.io.OutputStreamWriter')
 
 var jwt = {
+    version: '0.0.7',
     /**
     * Função que gera um **jwt** a partir de um *payload*.
     * @param {Object} payload - propriedades que serão inseridas no payload do jwt.


### PR DESCRIPTION
Conforme os parâmetros do GraalVM, uma String Java é `convertida` internamente para uma string do JavaScript; logo perdemos o método `.getBytes`.